### PR TITLE
fix: configurar setup-node para autenticar com GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          registry-url: https://npm.pkg.github.com/
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          registry-url: https://registry.npmjs.org/
+          registry-url: https://npm.pkg.github.com/
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
@@ -84,9 +84,7 @@ jobs:
       #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to Github (public package)
-        run: |
-          npm config set registry https://npm.pkg.github.com/
-          npm publish
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to Github (public package)
-        run: npm publish
+        run: pnpm publish --access restricted
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Resumo

- O `setup-node` estava configurado com `registry-url: https://registry.npmjs.org/`, mas o step de publish envia o pacote para `npm.pkg.github.com`
- Isso fazia com que o `npm publish` rodasse sem autenticação para o GitHub Packages, falhando silenciosamente desde o [commit 3242595](https://github.com/tbdcagro/ui-kit-icons/commit/3242595603) (9 de junho de 2025)
- Nenhuma versão do `@tbdcagro/ui-kit-icons` foi publicada no GitHub Packages desde essa alteração

## Alterações

- Apontar o `registry-url` do `setup-node` para `https://npm.pkg.github.com/` para que o `NODE_AUTH_TOKEN` seja configurado para o registry correto
- Remover o `npm config set registry` redundante do step de publish

## Após o merge

Será necessário disparar um novo release (push em `icons/**` ou `packages/**` na branch main) para publicar o pacote no GitHub Packages.